### PR TITLE
feat: add signup endpoint

### DIFF
--- a/src/adverts/dto/create-advert.dto.ts
+++ b/src/adverts/dto/create-advert.dto.ts
@@ -19,8 +19,8 @@ export class CreateAdvertDto {
     maxLength: 50,
     description: 'max length 50 characters',
   })
-  @IsString()
   @IsNotEmpty()
+  @IsString()
   @MaxLength(50)
   title: string;
 
@@ -29,8 +29,8 @@ export class CreateAdvertDto {
     maxLength: 500,
     description: 'max length 500 characters',
   })
-  @IsString()
   @IsNotEmpty()
+  @IsString()
   @MaxLength(500)
   description: string;
 
@@ -41,19 +41,21 @@ export class CreateAdvertDto {
     description: 'from 1.00 to 9999.99',
   })
   @Type(() => Number)
-  @IsNumber()
   @IsNotEmpty()
+  @IsNumber()
   @Min(1)
   @Max(9999.99)
   price: number;
 
   @ApiProperty({ required: true, enum: Category })
+  @IsNotEmpty()
   @IsString()
   @IsEnum(Category)
   category: string;
 
   @ApiProperty({ required: true })
   @Type(() => Boolean)
+  @IsNotEmpty()
   @IsBoolean()
   offer: boolean;
 

--- a/src/adverts/dto/update-advert.dto.ts
+++ b/src/adverts/dto/update-advert.dto.ts
@@ -1,0 +1,4 @@
+import { PartialType } from '@nestjs/swagger';
+import { CreateAdvertDto } from './create-advert.dto';
+
+export class UpdateAdvertDto extends PartialType(CreateAdvertDto) {}

--- a/src/auth/auth.controller.ts
+++ b/src/auth/auth.controller.ts
@@ -1,7 +1,9 @@
 import { Body, Controller, Post } from '@nestjs/common';
-import { LoginDto } from './dto/login.dto';
-import { ApiOkResponse, ApiTags } from '@nestjs/swagger';
+import { ApiCreatedResponse, ApiOkResponse, ApiTags } from '@nestjs/swagger';
 import { AuthService } from './auth.service';
+import { LoginDto } from './dto/login.dto';
+import { SignUpDto } from './dto/signup.dto';
+import { UserEntity } from 'src/users/entities/user.entity';
 
 @Controller('auth')
 @ApiTags('auth')
@@ -12,5 +14,11 @@ export class AuthController {
   @ApiOkResponse({ description: 'Returns a JWT access token' })
   async login(@Body() loginDto: LoginDto) {
     return this.authService.login(loginDto);
+  }
+
+  @Post('signup')
+  @ApiCreatedResponse({ type: UserEntity })
+  async signup(@Body() signupDto: SignUpDto) {
+    return this.authService.signup(signupDto);
   }
 }

--- a/src/auth/auth.module.ts
+++ b/src/auth/auth.module.ts
@@ -6,10 +6,11 @@ import { StringValue } from 'ms';
 import { PrismaModule } from 'src/prisma/prisma.module';
 import { PassportModule } from '@nestjs/passport';
 import { JwtStrategy } from './strategies/jwt.strategy';
+import { UsersService } from 'src/users/users.service';
 
 @Module({
   controllers: [AuthController],
-  providers: [AuthService, JwtStrategy],
+  providers: [AuthService, UsersService, JwtStrategy],
   imports: [
     PrismaModule,
     PassportModule,

--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -1,14 +1,17 @@
+import * as bcrypt from 'bcrypt';
 import { Injectable, UnauthorizedException } from '@nestjs/common';
 import { JwtService } from '@nestjs/jwt';
-import { LoginDto } from './dto/login.dto';
-import { PrismaService } from 'src/prisma/prisma.service';
-import * as bcrypt from 'bcrypt';
 import { Prisma } from '@prisma/client';
+import { LoginDto } from './dto/login.dto';
+import { SignUpDto } from './dto/signup.dto';
+import { PrismaService } from 'src/prisma/prisma.service';
+import { UsersService } from 'src/users/users.service';
 
 @Injectable()
 export class AuthService {
   constructor(
     private jwtService: JwtService,
+    private usersService: UsersService,
     private prisma: PrismaService,
   ) {}
 
@@ -19,24 +22,44 @@ export class AuthService {
       });
 
       if (!(await bcrypt.compare(user.password, foundUser.password))) {
-        throw new UnauthorizedException('Invalid email or password');
+        throw new UnauthorizedException('invalid email or password');
       }
 
-      return {
-        accessToken: this.jwtService.sign({
-          id: foundUser.id,
-          email: foundUser.email,
-          username: foundUser.username,
-        }),
-      };
+      const accessToken = this.jwtService.sign({
+        id: foundUser.id,
+        email: foundUser.email,
+        username: foundUser.username,
+      });
+
+      return { accessToken };
     } catch (error) {
       if (
         error instanceof Prisma.PrismaClientKnownRequestError &&
         error.code === 'P2025'
       ) {
-        throw new UnauthorizedException('Invalid email or password');
+        throw new UnauthorizedException('invalid email or password');
       }
 
+      throw error;
+    }
+  }
+
+  async signup(user: SignUpDto) {
+    try {
+      const newUser = await this.usersService.create({
+        email: user.email,
+        username: user.username,
+        password: user.password,
+      });
+
+      const accessToken = this.jwtService.sign({
+        id: newUser.id,
+        email: newUser.email,
+        username: newUser.username,
+      });
+
+      return { user: newUser, accessToken };
+    } catch (error) {
       throw error;
     }
   }

--- a/src/auth/dto/signup.dto.ts
+++ b/src/auth/dto/signup.dto.ts
@@ -11,29 +11,28 @@ import {
 
 export class SignUpDto {
   @ApiProperty({ required: true })
-  @IsEmail()
   @IsNotEmpty()
+  @IsEmail()
   email: string;
 
   @ApiProperty({ required: true })
+  @IsNotEmpty()
   @IsString()
   @MaxLength(16)
-  @IsNotEmpty()
   username: string;
 
   @ApiProperty({ required: true })
+  @IsNotEmpty()
   @IsString()
-  @IsNotEmpty()
   @MinLength(8)
-  @IsNotEmpty()
   password: string;
 
   @ApiProperty({ required: true })
+  @IsNotEmpty({ message: 'repeated password should not be empty' })
   @IsString()
   @MinLength(8, {
     message: 'repeated password must be longer than or equal to 8 characters',
   })
-  @IsNotEmpty({ message: 'repeated password should not be empty' })
   @ValidateIf((dto: SignUpDto) => dto.password !== dto.repeatedPassword)
   @Equals('password', { message: 'passwords do not match' })
   repeatedPassword: string;

--- a/src/auth/dto/signup.dto.ts
+++ b/src/auth/dto/signup.dto.ts
@@ -1,0 +1,40 @@
+import { ApiProperty } from '@nestjs/swagger';
+import {
+  Equals,
+  IsEmail,
+  IsNotEmpty,
+  IsString,
+  MaxLength,
+  MinLength,
+  ValidateIf,
+} from 'class-validator';
+
+export class SignUpDto {
+  @ApiProperty({ required: true })
+  @IsEmail()
+  @IsNotEmpty()
+  email: string;
+
+  @ApiProperty({ required: true })
+  @IsString()
+  @MaxLength(16)
+  @IsNotEmpty()
+  username: string;
+
+  @ApiProperty({ required: true })
+  @IsString()
+  @IsNotEmpty()
+  @MinLength(8)
+  @IsNotEmpty()
+  password: string;
+
+  @ApiProperty({ required: true })
+  @IsString()
+  @MinLength(8, {
+    message: 'repeated password must be longer than or equal to 8 characters',
+  })
+  @IsNotEmpty({ message: 'repeated password should not be empty' })
+  @ValidateIf((dto: SignUpDto) => dto.password !== dto.repeatedPassword)
+  @Equals('password', { message: 'passwords do not match' })
+  repeatedPassword: string;
+}

--- a/src/auth/guard/jwt-auth.guard.ts
+++ b/src/auth/guard/jwt-auth.guard.ts
@@ -1,25 +1,15 @@
 import { ExecutionContext, Injectable } from '@nestjs/common';
-import { Reflector } from '@nestjs/core';
 import { AuthGuard } from '@nestjs/passport';
 import { Observable } from 'rxjs';
-import { IS_PUBLIC_KEY } from '../decorator/public.decorator';
 
 @Injectable()
 export class JwtAuthGuard extends AuthGuard('jwt') {
-  constructor(private reflector: Reflector) {
+  constructor() {
     super();
   }
   canActivate(
     context: ExecutionContext,
   ): boolean | Promise<boolean> | Observable<boolean> {
-    const isPublic = this.reflector.getAllAndOverride<boolean>(IS_PUBLIC_KEY, [
-      context.getHandler(),
-      context.getClass(),
-    ]);
-
-    if (isPublic) {
-      return true;
-    }
     return super.canActivate(context);
   }
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,5 +1,5 @@
-import { ValidationPipe } from '@nestjs/common';
-import { NestFactory } from '@nestjs/core';
+import { ClassSerializerInterceptor, ValidationPipe } from '@nestjs/common';
+import { NestFactory, Reflector } from '@nestjs/core';
 import { DocumentBuilder, SwaggerModule } from '@nestjs/swagger';
 import { AppModule } from './app.module';
 import { PrismaClientExceptionFilter } from './utils/prisma-client-exception.filter';
@@ -41,6 +41,7 @@ async function bootstrap() {
     }),
   );
   app.useGlobalFilters(new PrismaClientExceptionFilter());
+  app.useGlobalInterceptors(new ClassSerializerInterceptor(app.get(Reflector)));
 
   await app.listen(port, () => {
     console.log(`Helpinaut API running in port ${port}`);

--- a/src/users/dto/create-user.dto.ts
+++ b/src/users/dto/create-user.dto.ts
@@ -1,18 +1,27 @@
 import { ApiProperty } from '@nestjs/swagger';
-import { IsEmail, IsString, MaxLength, MinLength } from 'class-validator';
+import {
+  IsEmail,
+  IsNotEmpty,
+  IsString,
+  MaxLength,
+  MinLength,
+} from 'class-validator';
 
 export class CreateUserDto {
   @ApiProperty({ required: true })
   @IsEmail()
+  @IsNotEmpty()
   email: string;
 
   @ApiProperty({ required: true })
   @IsString()
+  @IsNotEmpty()
   @MaxLength(16)
   username: string;
 
   @ApiProperty({ required: true })
   @IsString()
+  @IsNotEmpty()
   @MinLength(8)
   password: string;
 }

--- a/src/users/dto/create-user.dto.ts
+++ b/src/users/dto/create-user.dto.ts
@@ -9,19 +9,19 @@ import {
 
 export class CreateUserDto {
   @ApiProperty({ required: true })
-  @IsEmail()
   @IsNotEmpty()
+  @IsEmail()
   email: string;
 
   @ApiProperty({ required: true })
-  @IsString()
   @IsNotEmpty()
+  @IsString()
   @MaxLength(16)
   username: string;
 
   @ApiProperty({ required: true })
-  @IsString()
   @IsNotEmpty()
+  @IsString()
   @MinLength(8)
   password: string;
 }

--- a/src/users/entities/user.entity.ts
+++ b/src/users/entities/user.entity.ts
@@ -5,6 +5,10 @@ import { Exclude } from 'class-transformer';
 type UserWithoutPassword = Omit<User, 'password'>;
 
 export class UserEntity implements UserWithoutPassword {
+  constructor(partial: Partial<UserEntity>) {
+    Object.assign(this, partial);
+  }
+
   @ApiProperty()
   id: string;
 

--- a/src/users/users.controller.ts
+++ b/src/users/users.controller.ts
@@ -6,12 +6,14 @@ import {
   Patch,
   Param,
   Delete,
+  UseGuards,
 } from '@nestjs/common';
 import { ApiCreatedResponse, ApiTags } from '@nestjs/swagger';
 import { UserEntity } from './entities/user.entity';
 import { UsersService } from './users.service';
 import { CreateUserDto } from './dto/create-user.dto';
 import { UpdateUserDto } from './dto/update-user.dto';
+import { JwtAuthGuard } from 'src/auth/guard/jwt-auth.guard';
 
 @Controller('users')
 @ApiTags('users')
@@ -25,24 +27,28 @@ export class UsersController {
   }
 
   @Get()
+  @UseGuards(JwtAuthGuard)
   @ApiCreatedResponse({ type: UserEntity, isArray: true })
   findAll() {
     return this.usersService.findAll();
   }
 
   @Get(':id')
+  @UseGuards(JwtAuthGuard)
   @ApiCreatedResponse({ type: UserEntity })
   findOne(@Param('id') id: string) {
     return this.usersService.findOne(id);
   }
 
   @Patch(':id')
+  @UseGuards(JwtAuthGuard)
   @ApiCreatedResponse({ type: UserEntity })
   update(@Param('id') id: string, @Body() updateUserDto: UpdateUserDto) {
     return this.usersService.update(id, updateUserDto);
   }
 
   @Delete(':id')
+  @UseGuards(JwtAuthGuard)
   @ApiCreatedResponse({ type: UserEntity })
   remove(@Param('id') id: string) {
     return this.usersService.remove(id);

--- a/src/users/users.service.ts
+++ b/src/users/users.service.ts
@@ -1,82 +1,78 @@
 import { Injectable } from '@nestjs/common';
-import { hash, genSalt } from 'bcrypt';
+import * as bcrypt from 'bcrypt';
 import { CreateUserDto } from './dto/create-user.dto';
 import { UpdateUserDto } from './dto/update-user.dto';
 import { PrismaService } from 'src/prisma/prisma.service';
+import { UserEntity } from './entities/user.entity';
 
 @Injectable()
 export class UsersService {
   constructor(private prisma: PrismaService) {}
 
   /**
-   * This action adds a new user with hashed password.
+   * This action adds a new user with hashed password. UserEntity prevents excluded properties from being shown.
    * @param createUserDto
-   * @returns
+   * @returns UserEntity
    */
   async create(createUserDto: CreateUserDto) {
-    const hashedPassword = await hash(createUserDto.password, 12);
-    return this.prisma.user.create({
+    const hashedPassword = await bcrypt.hash(createUserDto.password, 12);
+    const newUser = await this.prisma.user.create({
       data: { ...createUserDto, password: hashedPassword },
     });
+
+    return new UserEntity(newUser);
   }
 
   /**
-   * This action returns all users.
-   * @returns
+   * This action returns all users. UserEntity prevents excluded properties from being shown.
+   * @returns UserEntity[]
    */
-  findAll() {
-    return this.prisma.user.findMany({
-      select: {
-        id: true,
-        email: true,
-        username: true,
-        // adverts: true,
-        // favorites: true,
-        createdAt: true,
-        updatedAt: true,
-      },
-    });
+  async findAll() {
+    const users = await this.prisma.user.findMany();
+
+    return users.map((user) => new UserEntity(user));
   }
 
   /**
-   * This action returns a #id user.
+   * This action returns a selected user. UserEntity prevents excluded properties from being shown.
    * @param id
-   * @returns
+   * @returns UserEntity
    */
-  findOne(id: string) {
-    return this.prisma.user.findUniqueOrThrow({
+  async findOne(id: string) {
+    const user = await this.prisma.user.findUniqueOrThrow({
       where: { id },
-      select: {
-        id: true,
-        email: true,
-        username: true,
-        adverts: true,
-        favorites: true,
-        createdAt: true,
-        updatedAt: true,
-      },
     });
+
+    return new UserEntity(user);
   }
 
   /**
-   * This action updates a #id user.
+   * This action updates a selected user. UserEntity prevents excluded properties from being shown.
    * @param id
    * @param updateUserDto
-   * @returns
+   * @returns UserEntity
    */
   async update(id: string, updateUserDto: UpdateUserDto) {
     if (updateUserDto.password) {
-      updateUserDto.password = await hash(updateUserDto.password, 12);
+      updateUserDto.password = await bcrypt.hash(updateUserDto.password, 12);
     }
-    return this.prisma.user.update({ where: { id }, data: updateUserDto });
+
+    const updatedUser = await this.prisma.user.update({
+      where: { id },
+      data: updateUserDto,
+    });
+
+    return new UserEntity(updatedUser);
   }
 
   /**
-   * This action removes a #id user.
+   * This action removes a selected user. UserEntity prevents excluded properties from being shown.
    * @param id
-   * @returns
+   * @returns UserEntity
    */
-  remove(id: string) {
-    return this.prisma.user.delete({ where: { id } });
+  async remove(id: string) {
+    const deletedUser = await this.prisma.user.delete({ where: { id } });
+
+    return new UserEntity(deletedUser);
   }
 }

--- a/src/utils/prisma-client-exception.filter.ts
+++ b/src/utils/prisma-client-exception.filter.ts
@@ -20,22 +20,22 @@ export class PrismaClientExceptionFilter extends BaseExceptionFilter {
          * Unique constraint violation
          */
         const target = (exception.meta?.target ?? []) as string[];
-        throw new ConflictException(`This ${target} is already in use`);
+        throw new ConflictException(`this ${target} is already in use`);
       }
       case 'P2003': {
         /**
          * Foreign key constraint violation
          */
-        throw new UnprocessableEntityException("Entity doesn't exist");
+        throw new UnprocessableEntityException("entity doesn't exist");
       }
       case 'P2025': {
         /**
          * Non-existing object
          */
-        throw new NotFoundException('Resource not found');
+        throw new NotFoundException('resource not found');
       }
       default:
-        throw new InternalServerErrorException('Internal server error');
+        throw new InternalServerErrorException('internal server error');
     }
   }
 }


### PR DESCRIPTION
This pull request adds signup endpoint to auth module. Signup dto has an additional and validated repeated password property. Taking advantage of the use of user service's create() in the signup function, now this and the rest of user service function returns UserEntity. This is due to the now included ClassSerializerInterceptor defined as global interceptor, which will exclude passwords  (and other explicitly excluded fields) in responses as it was intended and declared in UserEntity class.

Global JwtAuthGlobal and @Public decorator have been removed, so now this guard must be used individually for each endpoint that may require it.