### PR TITLE
feat: add favorite adverts

### DIFF
--- a/src/adverts/adverts.controller.ts
+++ b/src/adverts/adverts.controller.ts
@@ -146,6 +146,14 @@ export class AdvertsController {
     return this.advertsService.removePhoto(id, photoId, userId);
   }
 
+  @Get('favorites/me')
+  @UseGuards(JwtAuthGuard)
+  @ApiBearerAuth()
+  @ApiOkResponse({ type: AdvertEntity })
+  async findFavorites(@GetUser('id') userId: string) {
+    return this.advertsService.findFavorites(userId);
+  }
+
   @Post(':id/favorites')
   @UseGuards(JwtAuthGuard)
   @ApiBearerAuth()

--- a/src/adverts/adverts.controller.ts
+++ b/src/adverts/adverts.controller.ts
@@ -67,12 +67,6 @@ export class AdvertsController {
     return this.advertsService.create(createAdvertDto, userId, photoPaths);
   }
 
-  @Get('categories')
-  @ApiOkResponse({ type: String, isArray: true })
-  async findCategories() {
-    return this.advertsService.findCategories();
-  }
-
   @Get()
   @UseGuards(OptionalJwtAuthGuard)
   @ApiBearerAuth()
@@ -112,6 +106,12 @@ export class AdvertsController {
   @ApiOkResponse({ type: AdvertEntity })
   async remove(@Param('id') id: string, @GetUser('id') userId: string) {
     return this.advertsService.remove(id, userId);
+  }
+
+  @Get('categories')
+  @ApiOkResponse({ type: String, isArray: true })
+  async findCategories() {
+    return this.advertsService.findCategories();
   }
 
   @Post(':id/photos')

--- a/src/adverts/adverts.controller.ts
+++ b/src/adverts/adverts.controller.ts
@@ -7,7 +7,6 @@ import {
   Param,
   Patch,
   Post,
-  Req,
   UploadedFiles,
   UseGuards,
   UseInterceptors,
@@ -145,5 +144,21 @@ export class AdvertsController {
     @GetUser('id') userId: string,
   ) {
     return this.advertsService.removePhoto(id, photoId, userId);
+  }
+
+  @Post(':id/favorites')
+  @UseGuards(JwtAuthGuard)
+  @ApiBearerAuth()
+  @ApiOkResponse({ description: 'advert added to favorites' })
+  async addFavorite(@Param('id') id: string, @GetUser('id') userId: string) {
+    return this.advertsService.addFavorite(id, userId);
+  }
+
+  @Delete(':id/favorites')
+  @UseGuards(JwtAuthGuard)
+  @ApiBearerAuth()
+  @ApiOkResponse({ description: 'advert removed from favorites' })
+  async removeFavorite(@Param('id') id: string, @GetUser('id') userId: string) {
+    return this.advertsService.removeFavorite(id, userId);
   }
 }

--- a/src/adverts/adverts.service.ts
+++ b/src/adverts/adverts.service.ts
@@ -250,4 +250,26 @@ export class AdvertsService {
 
     return { message: 'advert added to favorites' };
   }
+
+  /**
+   * This action removes a selected advert from favorite list.
+   * @param advertId
+   * @param userId
+   * @returns
+   */
+  async removeFavorite(advertId: string, userId: string) {
+    const favorite = await this.prisma.favorite.findUniqueOrThrow({
+      where: { userId_advertId: { userId, advertId } },
+    });
+
+    if (favorite.userId !== userId) {
+      throw new UnauthorizedException('unauthorized to modify this advert');
+    }
+
+    await this.prisma.favorite.delete({
+      where: { userId_advertId: { userId, advertId } },
+    });
+
+    return { message: 'advert removed from favorites' };
+  }
 }

--- a/src/adverts/adverts.service.ts
+++ b/src/adverts/adverts.service.ts
@@ -1,4 +1,9 @@
-import { BadRequestException, Injectable } from '@nestjs/common';
+import {
+  BadRequestException,
+  ForbiddenException,
+  Injectable,
+  UnauthorizedException,
+} from '@nestjs/common';
 
 import { Category, Status } from '@prisma/client';
 import { CreateAdvertDto } from './dto/create-advert.dto';
@@ -155,6 +160,13 @@ export class AdvertsService {
     return new AdvertEntity(deletedAdvert);
   }
 
+  /**
+   * This action adds photo objects to a selected advert photo array property.
+   * @param advertId
+   * @param userId
+   * @param photoPaths
+   * @returns
+   */
   async addPhoto(advertId: string, userId: string, photoPaths: string[]) {
     const advert = await this.prisma.advert.findUniqueOrThrow({
       where: { id: advertId },
@@ -179,6 +191,13 @@ export class AdvertsService {
     });
   }
 
+  /**
+   * This action removes photo object to a selected advert photo array property.
+   * @param advertId
+   * @param photoId
+   * @param userId
+   * @returns
+   */
   async removePhoto(advertId: string, photoId: string, userId: string) {
     const advert = await this.prisma.advert.findUniqueOrThrow({
       where: { id: advertId },
@@ -200,5 +219,35 @@ export class AdvertsService {
       photos: updatedAdvert.photos.map((photo) => new PhotoEntity(photo)),
       isOwner: true,
     });
+  }
+
+  /**
+   * This action adds a selected advert to favorite list.
+   * @param advertId
+   * @param userId
+   * @returns
+   */
+  async addFavorite(advertId: string, userId: string) {
+    const advert = await this.prisma.advert.findUniqueOrThrow({
+      where: { id: advertId },
+    });
+
+    if (advert.ownerId === userId) {
+      throw new ForbiddenException(
+        'owned adverts cannot be marked as favorite',
+      );
+    }
+
+    if (
+      await this.prisma.favorite.findUnique({
+        where: { userId_advertId: { userId, advertId } },
+      })
+    ) {
+      throw new ForbiddenException('this advert is already marked as favorite');
+    }
+
+    await this.prisma.favorite.create({ data: { userId, advertId } });
+
+    return { message: 'advert added to favorites' };
   }
 }

--- a/src/adverts/adverts.service.ts
+++ b/src/adverts/adverts.service.ts
@@ -80,6 +80,11 @@ export class AdvertsService {
           ...advert,
           owner: new PublicUserEntity(advert.owner),
           isOwner: userId ? advert.ownerId === userId : false,
+          isFavorite: userId
+            ? this.prisma.favorite.findUnique({
+                where: { userId_advertId: { userId, advertId: advert.id } },
+              }) !== null
+            : false,
         }),
     );
   }
@@ -100,6 +105,11 @@ export class AdvertsService {
       owner: new PublicUserEntity(advert.owner),
       photos: advert.photos.map((photo) => new PhotoEntity(photo)),
       isOwner: userId ? advert.ownerId === userId : false,
+      isFavorite: userId
+        ? this.prisma.favorite.findUnique({
+            where: { userId_advertId: { userId, advertId: advert.id } },
+          }) !== null
+        : false,
     });
   }
 

--- a/src/adverts/adverts.service.ts
+++ b/src/adverts/adverts.service.ts
@@ -272,4 +272,30 @@ export class AdvertsService {
 
     return { message: 'advert removed from favorites' };
   }
+
+  async findFavorites(userId: string) {
+    const favorites = await this.prisma.favorite.findMany({
+      where: { userId },
+      include: {
+        advert: {
+          include: {
+            photos: true,
+            owner: { select: { username: true } },
+          },
+        },
+      },
+      orderBy: { createdAt: 'desc' },
+    });
+
+    return favorites.map(
+      (favorite) =>
+        new AdvertEntity({
+          ...favorite.advert,
+          owner: new PublicUserEntity(favorite.advert.owner),
+          photos: favorite.advert.photos.map((photo) => new PhotoEntity(photo)),
+          isOwner: false,
+          isFavorite: true,
+        }),
+    );
+  }
 }

--- a/src/adverts/entities/advert.entity.ts
+++ b/src/adverts/entities/advert.entity.ts
@@ -57,6 +57,10 @@ export class AdvertEntity {
   @Expose()
   isOwner: boolean;
 
+  @ApiProperty()
+  @Expose()
+  isFavorite: boolean;
+
   /**
    * Private properties
    */

--- a/src/users/users.service.ts
+++ b/src/users/users.service.ts
@@ -41,7 +41,14 @@ export class UsersService {
   async findOne(id: string) {
     const user = await this.prisma.user.findUniqueOrThrow({
       where: { id },
-      include: { adverts: true, favorites: { include: { advert: true } } },
+      include: {
+        adverts: {
+          include: {
+            photos: true,
+            owner: { select: { username: true } },
+          },
+        },
+      },
     });
 
     return new UserEntity(user);

--- a/src/users/users.service.ts
+++ b/src/users/users.service.ts
@@ -41,6 +41,7 @@ export class UsersService {
   async findOne(id: string) {
     const user = await this.prisma.user.findUniqueOrThrow({
       where: { id },
+      include: { adverts: true, favorites: { include: { advert: true } } },
     });
 
     return new UserEntity(user);

--- a/src/utils/check-ownership.util.ts
+++ b/src/utils/check-ownership.util.ts
@@ -1,10 +1,10 @@
-import { ForbiddenException } from '@nestjs/common';
+import { UnauthorizedException } from '@nestjs/common';
 
 export function checkOwnership<T extends Record<string, any>>(
   resource: T,
   userId: string,
 ): void {
   if (resource['ownerId'] !== userId) {
-    throw new ForbiddenException('unauthorized to modify this advert');
+    throw new UnauthorizedException('unauthorized to modify this advert');
   }
 }


### PR DESCRIPTION
This pull request adds the new favorite feature. Authenticated users can add adverts (that don't belong to them) to their favorite adverts lists. Favorite model was already included in Prisma schema.

There are new endpoints documented: `POST /adverts/{id}/favorites` to add a selected advert to user favorites list, `DELETE /adverts/{id}/favorites` to remove a selected advert from user favorites list and `GET /adverts/favorites/me` to get the list of favorite adverts of the authenticated user.